### PR TITLE
Enable use of Android emulator as device target

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Task targets, files and options may be specified according to the grunt [Configu
 
 ### Available commands & options
 
-The options `wait`, `debug`, and `device` are defined for all commands.
+The options `wait`, `debug`, `emulator`, and `device` are defined for all commands.
 
 #### install
 The path to the `.apk` file to install 

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -17,8 +17,10 @@ module.exports = function(grunt) {
     grunt.registerMultiTask('adb', 'Launch ADB commands from Grunt', function() {
         var done = this.async();
 
-        // handle device option, or select the only USB conected device
-        if (typeof this.data.device === 'undefined') {
+        // handle emulator / device option, or select the only USB conected device
+        if (typeof this.data.emulator !== 'undefined') {
+            this.data.device = ' -e ';
+        } else if (typeof this.data.device === 'undefined') {
             this.data.device = ' -d ';
         } else {
             this.data.device = ' -s ' + this.data.device;


### PR DESCRIPTION
Hi,

This pull request does what it says in the title -- allows you to specify that commands should target the currently active Android emulator.

Let me know if you have any feedback.
