### PR TITLE
Launch app correctly and allow alternative launch activity

### DIFF
--- a/tasks/index.js
+++ b/tasks/index.js
@@ -48,6 +48,13 @@ module.exports = function(grunt) {
             this.data.action = ' -a ' + this.data.action;
         }
 
+        // handle activity option
+        if(!this.data.activity) {
+            this.data.activity = ''
+        } else {
+            this.data.activity = '/' + this.data.activity;
+        }
+
 
         // UNINSTALL
         if (this.data.uninstall) {
@@ -65,7 +72,7 @@ module.exports = function(grunt) {
 
         // AM START aka LAUNCH
         if (this.data.launch) {
-            run('adb ' + this.data.device + ' shell am start ' + this.data.wait  + this.data.debug + this.data.action + ' -n ' + this.data.launch, function(error){
+            run('adb ' + this.data.device + ' shell am start ' + this.data.wait  + this.data.debug + this.data.action + ' ' + this.data.launch + this.data.activity, function(error){
                 done(error);
             });
         }


### PR DESCRIPTION
Hi,

There seems to be no `-n` option in the [current adb docs](http://developer.android.com/tools/help/adb.html), so after trying a bunch of options, I was able to get my app to launch by changing the argument order to adb shell am start as the commit does.  I also added an extra parameter to allow starting an app with a non-standard entry point activity (as my Cordova-based app requires).

I don't think this will break anyone's build process but it might be worth some testing.

Let me know.
